### PR TITLE
install all package files together

### DIFF
--- a/irods_python_ci_utilities/irods_python_ci_utilities.py
+++ b/irods_python_ci_utilities/irods_python_ci_utilities.py
@@ -103,9 +103,11 @@ def install_os_packages(packages):
         raise_not_implemented_for_distribution()
 
 def install_os_packages_from_files_apt(files):
-    # Files are installed individually in the order supplied, so inter-file dependencies must be handled by the caller
-    for f in files:
-        subprocess_get_output(['sudo', 'apt', 'install', '-fy', f], check_rc=True)
+    if len(files) > 0:
+        # If several package files are present, they should be installed simultaneously, ie.
+        # within the same command, so that possible dependencies between them are recognized.
+        args = ['sudo', 'apt', 'install', '-fy'] + list(files)
+        subprocess_get_output(args, check_rc=True)
 
 def install_os_packages_from_files_dnf(files):
     subprocess_get_output(['sudo', 'dnf', 'update', '-y'], check_rc=True)


### PR DESCRIPTION
this runs a single apt install command on all package files needing installation (rather than looping over the elements of the package list and installing individually) in case they might have interdependencies.  This should free the caller from having to arrange the listed order of the packages to account for those dependencies.