### PR TITLE
[irods/irods_testing_environment#113] Do not run "dnf update" before installing RPM packages

### DIFF
--- a/irods_python_ci_utilities/irods_python_ci_utilities.py
+++ b/irods_python_ci_utilities/irods_python_ci_utilities.py
@@ -113,7 +113,6 @@ def install_os_packages_from_files_apt(files):
         subprocess_get_output(args, check_rc=True)
 
 def install_os_packages_from_files_dnf(files):
-    subprocess_get_output(['sudo', 'dnf', 'update', '-y'], check_rc=True)
     args = ['sudo', 'dnf', 'localinstall', '-y', '--nogpgcheck'] + list(files)
     subprocess_get_output(args, check_rc=True)
 


### PR DESCRIPTION
Needed for automated testing in GitHub Actions.

This makes it possible to test against older versions of iRODS.