### PR TITLE
[#26] Fix packages not building due to missing path

### DIFF
--- a/irods_python_ci_utilities/irods_python_ci_utilities.py
+++ b/irods_python_ci_utilities/irods_python_ci_utilities.py
@@ -9,6 +9,7 @@ import sys
 import tempfile
 import time
 import urllib.request
+from pathlib import Path
 
 from . import copied_from_ansible
 
@@ -144,6 +145,10 @@ def install_os_packages_from_files(files):
 
 def install_irods_core_dev_repository_apt():
     install_os_packages_apt(['ca-certificates', 'gnupg', 'lsb-release'])
+
+    # Ensure directory exists for the following gpg command
+    Path('/etc/apt/keyrings').mkdir(parents=True, exist_ok=True)
+
     gpg_cmd = [
         'sudo',
         'gpg',


### PR DESCRIPTION
Debian 11 plugin packages would not build due to missing path.